### PR TITLE
Load statline modifiers from xwing-data

### DIFF
--- a/mic/src/mic/MasterUpgradeData.java
+++ b/mic/src/mic/MasterUpgradeData.java
@@ -1,0 +1,85 @@
+package mic;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+/**
+ * Created by guido on 11/02/17.
+ */
+public class MasterUpgradeData extends ArrayList<MasterUpgradeData.UpgradeData> {
+
+  private static Map<String, UpgradeData> loadedData = null;
+
+  public static Map<String, UpgradeData> getUpgradeDataByXWSId() {
+      if (loadedData != null) {
+          return loadedData;
+      }
+
+      loadedData = Maps.newHashMap();
+      MasterUpgradeData data = Util.loadRemoteJson(
+          "https://raw.githubusercontent.com/guidokessels/xwing-data/master/data/upgrades.js",
+          MasterUpgradeData.class);
+
+      for(UpgradeData upgrade : data) {
+          loadedData.put(upgrade.getXws(), upgrade);
+      }
+      return loadedData;
+  }
+
+  public static class UpgradeData {
+
+      @JsonProperty("name")
+      private String name;
+
+      @JsonProperty("xws")
+      private String xws;
+
+      @JsonProperty("grants")
+      private ArrayList<UpgradeGrants> grants = Lists.newArrayList();
+
+      public ArrayList<UpgradeGrants> getGrants() {
+          return grants;
+      }
+
+      public String getXws() {
+          return xws;
+      }
+
+      public String getName() {
+          return name;
+      }
+  }
+
+  public static class UpgradeGrants {
+
+      @JsonProperty("name")
+      private String name;
+
+      @JsonProperty("type")
+      private String type;
+
+      @JsonProperty("value")
+      private int value;
+
+      public String getName() {
+          return name;
+      }
+
+      public String getType() {
+          return type;
+      }
+
+      public int getValue() {
+          return value;
+      }
+
+      public boolean isStatsModifier() {
+          return type.equals("stats");
+      }
+  };
+}

--- a/mic/src/mic/VassalXWSPieceLoader.java
+++ b/mic/src/mic/VassalXWSPieceLoader.java
@@ -84,11 +84,20 @@ public class VassalXWSPieceLoader {
         String upgradeType = getCleanedName(listWidget.getConfigureName());
         upgradeType = NameFixes.fixUpgradeTypeName(upgradeType);
         List<PieceSlot> upgrades = listWidget.getAllDescendantComponentsOf(PieceSlot.class);
+
         for (PieceSlot upgrade : upgrades) {
             String upgradeName = getCleanedName(upgrade.getConfigureName());
             upgradeName = NameFixes.fixUpgradeName(upgradeType, upgradeName);
+
             String mapKey = getUpgradeMapKey(upgradeType, upgradeName);
-            upgradePiecesMap.put(mapKey, new VassalXWSPilotPieces.Upgrade(upgradeName, upgrade));
+            VassalXWSPilotPieces.Upgrade upgradePiece = new VassalXWSPilotPieces.Upgrade(upgradeName, upgrade);
+
+            MasterUpgradeData.UpgradeData upgradeData = MasterUpgradeData.getUpgradeDataByXWSId().get(upgradeName);
+            if (upgradeData != null) {
+                upgradePiece.setUpgradeData(upgradeData);
+            }
+
+            upgradePiecesMap.put(mapKey, upgradePiece);
         }
     }
 


### PR DESCRIPTION
Instead of hardcoding each card we can read the statline modifiers from the `grants` fields in xwing-data.

Example:
 http://yasb-xws.herokuapp.com/?f=Scum%20and%20Villainy&d=v4!s!107::17:1:U.-1&sn=Unsaved%20Squadron
<img width="651" alt="screen shot 2017-02-12 at 00 55 03" src="https://cloud.githubusercontent.com/assets/834902/22858472/c4d1e1e0-f0be-11e6-8f14-298f83a284c2.png">