### PR TITLE
Update acronymizer to use first word for unique pilots

### DIFF
--- a/mic/src/mic/MasterPilotData.java
+++ b/mic/src/mic/MasterPilotData.java
@@ -45,6 +45,13 @@ public class MasterPilotData extends ArrayList<MasterPilotData.PilotData> {
         @JsonProperty("xws")
         private String xws;
 
+        @JsonProperty("unique")
+        private boolean unique;
+
+        public boolean isUnique() {
+            return unique;
+        }
+
         public int getSkill() {
             try {
                 return Integer.parseInt(skill);

--- a/mic/src/mic/VassalXWSPilotPieces.java
+++ b/mic/src/mic/VassalXWSPilotPieces.java
@@ -215,9 +215,10 @@ public class VassalXWSPilotPieces {
 
     private String acronymizer(String cardName, boolean isUnique) {
         String name = cardName.replace("\"", "");
+        String firstWord = name.split(" ")[0];
 
         if(name.length() <= 8) return name;
-        else if (isUnique && name.contains(" ")) return name.split(" ")[0];
+        else if (isUnique && name.contains(" ") && firstWord.length() <= 8) return firstWord;
         else if(name.split("\\w+").length == 1) return name.substring(0, 8);
         else {
             String firstLetters = "";

--- a/mic/src/mic/VassalXWSPilotPieces.java
+++ b/mic/src/mic/VassalXWSPilotPieces.java
@@ -196,7 +196,7 @@ public class VassalXWSPilotPieces {
     private String getDisplayPilotName() {
         String pilotName = "";
         if (pilotData != null) {
-            pilotName = acronymizer(this.pilotData.getName());
+            pilotName = acronymizer(this.pilotData.getName(), this.pilotData.isUnique());
         }
 
         if (shipNumber != null && shipNumber > 0) {
@@ -213,12 +213,15 @@ public class VassalXWSPilotPieces {
         return pilotData;
     }
 
-    private String acronymizer(String input) {
-        if(input.length() <= 8)  return input;
-        else if(input.split("\\w+").length == 1) return input.substring(0, 8);
+    private String acronymizer(String cardName, boolean isUnique) {
+        String name = cardName.replace("\"", "");
+
+        if(name.length() <= 8) return name;
+        else if (isUnique && name.contains(" ")) return name.split(" ")[0];
+        else if(name.split("\\w+").length == 1) return name.substring(0, 8);
         else {
             String firstLetters = "";
-            for(String s: input.split(" ")){
+            for(String s: name.split(" ")){
                 if(s.charAt(0)=='\"') firstLetters += s.charAt(1);
                 else firstLetters += s.charAt(0);
             }


### PR DESCRIPTION
For unique cards with long names I suggest we try to use the first word.

We’ll get `Biggs`, `Wes` and `Corran` instead of `BD`, `WJ` and `CH`. 

It doesn’t always work perfectly (`Darth Vader` becomes `Darth`, but `Vader` would be better. `Colonel Vessery` becomes `Colonel` instead of `Vessery`) but I think it's better than the current solution. If we’d like to get perfect acronyms for all names I think we’d need to maintain a list of acronyms, which I think is too much hassle. However, if we would like to go down that path I can provide the JSON file of acronyms I use for my Chrome extension.

I also removed quotes from names as it takes up space on the base/dial without really adding anything. So now `”Whisper”` will be shown as `Whisper` instead of `W` (as it’s no longer more than 8 characters).

Before & after:
<img width="304" alt="screen shot 2017-02-12 at 08 38 13" src="https://cloud.githubusercontent.com/assets/834902/22860813/17447dda-f109-11e6-8a80-7aef3a181ad7.png"> <img width="316" alt="screen shot 2017-02-12 at 09 20 48" src="https://cloud.githubusercontent.com/assets/834902/22860812/13f1737c-f109-11e6-828f-baa67e76deae.png">
