### PR TITLE
Fix: Map `yt2400freighter` ship name to `yt2400`

### DIFF
--- a/mic/src/mic/XWSList.java
+++ b/mic/src/mic/XWSList.java
@@ -98,6 +98,9 @@ public class XWSList {
         }
 
         public String getShip() {
+            if (ship.equals("yt2400freighter")) {
+              return "yt2400";
+            }
             return ship;
         }
 

--- a/mic/src/mic/XWSList.java
+++ b/mic/src/mic/XWSList.java
@@ -98,7 +98,7 @@ public class XWSList {
         }
 
         public String getShip() {
-            if (ship.equals("yt2400freighter")) {
+            if ("yt2400freighter".equals(ship)) {
               return "yt2400";
             }
             return ship;


### PR DESCRIPTION
All squad builders use the xws id `yt2400freighter` instead of what’s in the spec: `yt2400`. At the moment this means Vassal cannot spawn _any_ of the YT-2400 pilots. There’s an ongoing discussion about this on the xws-spec repo on Github. At the moment it’s unclear yet whether the spec will change or whether all the squad builders will update their code to match the spec.

This fix is a bit dirty but it will work for both cases. Once the discussion has come to an agreement we can remove this code again.