### PR TITLE
Show list url in chat after spawning

### DIFF
--- a/mic/src/mic/AutoSquadSpawn.java
+++ b/mic/src/mic/AutoSquadSpawn.java
@@ -67,7 +67,7 @@ public class AutoSquadSpawn extends AbstractConfigurable implements CommandEncod
             url = JOptionPane.showInputDialog("Please paste a voidstate url or ID, YASB url, or FABS url");
         }
         catch ( Exception e ) {
-            logToChat("unable to process url, please try again");
+            logToChat("Unable to process url, please try again");
         }
         if (url == null || url.length() == 0) {
             return;
@@ -81,18 +81,19 @@ public class AutoSquadSpawn extends AbstractConfigurable implements CommandEncod
                 return;
             }
         } catch (Exception e) {
-            logToChat("unable to translate xws url: \n" + e.toString());
+            logToChat("Unable to translate xws url: \n" + e.toString());
             return;
         }
 
-        VassalXWSListPieces pieces = slotLoader.loadListFromXWS(XWSFetcher.fetchFromUrl(translatedURL.toString()));
+        XWSList xwsList = XWSFetcher.fetchFromUrl(translatedURL.toString());
+        VassalXWSListPieces pieces = slotLoader.loadListFromXWS(xwsList);
 
         Point startPosition = new Point(500,50);
         int fudgePilotUpgradeFrontier = -50;
         int totalPilotHeight = 0;
 
         for (VassalXWSPilotPieces ship : pieces.getShips()) {
-            logToChat(String.format("pilot: %s, gpid=%s", ship.getPilotCard().getConfigureName(), ship.getPilotCard().getGpId()));
+            logToChat(String.format("Spawning pilot: %s", ship.getPilotCard().getConfigureName()));
 
             GamePiece pilotPiece = ship.clonePilotCard();
             int pilotWidth = (int)pilotPiece.boundingBox().getWidth();
@@ -143,6 +144,11 @@ public class AutoSquadSpawn extends AbstractConfigurable implements CommandEncod
                 totalChitWidth += token.boundingBox().getWidth();
             }// loop to next token
         } //loop to next pilot
+
+        String listName = xwsList.getName();
+        logToChat(String.format("List%s loaded from %s",
+                                listName != null ? " " + listName : "",
+                                url));
 
     }
 


### PR DESCRIPTION
This will share the list URL in chat after spawning it. This makes it easier for your opponent or any observers to open your list in a squad builder.

If the returned xws has a `name` property the squad name will be shown as well. At the moment only Voidstate returns this property.

<img width="488" alt="screen shot 2017-02-15 at 00 12 28" src="https://cloud.githubusercontent.com/assets/834902/22963751/e9b5e72a-f354-11e6-95bb-c1db66d99fa8.png">
