### PR TITLE
Fix ORS stats

### DIFF
--- a/mic/src/mic/MasterPilotData.java
+++ b/mic/src/mic/MasterPilotData.java
@@ -53,6 +53,13 @@ public class MasterPilotData extends ArrayList<MasterPilotData.PilotData> {
         @JsonProperty("conditions")
         private List<String> conditions = Lists.newArrayList();
 
+        @JsonProperty("ship_override")
+        private ShipOverrides shipOverrides;
+
+        public ShipOverrides getShipOverrides() {
+            return shipOverrides;
+        }
+
         public boolean isUnique() {
             return unique;
         }
@@ -79,6 +86,29 @@ public class MasterPilotData extends ArrayList<MasterPilotData.PilotData> {
 
         public List<String> getConditions() {
             return conditions;
+        }
+    }
+
+    public static class ShipOverrides {
+        private int attack;
+        private int agility;
+        private int hull;
+        private int shields;
+
+        public int getAttack() {
+            return attack;
+        }
+
+        public int getAgility() {
+            return agility;
+        }
+
+        public int getHull() {
+            return hull;
+        }
+
+        public int getShields() {
+            return shields;
         }
     }
 }

--- a/mic/src/mic/VassalXWSPilotPieces.java
+++ b/mic/src/mic/VassalXWSPilotPieces.java
@@ -176,6 +176,14 @@ public class VassalXWSPilotPieces {
             int shields = this.shipData.getShields();
             int attack = this.shipData.getAttack();
 
+            MasterPilotData.ShipOverrides shipOverrides = this.pilotData.getShipOverrides();
+            if (shipOverrides != null) {
+              agility = shipOverrides.getAgility();
+              hull = shipOverrides.getHull();
+              shields = shipOverrides.getShields();
+              attack = shipOverrides.getAttack();
+            }
+
             piece.setProperty("Defense Rating", agility + agilityModifier);
             piece.setProperty("Hull Rating", hull + hullModifier);
             piece.setProperty("Attack Rating", attack + attackModifier);


### PR DESCRIPTION
Pilots can have a `ship_overrides` field in xwing-data if they override the base stats of the ship. Currently _Outer Rim Smuggler_ is the only card that does this.

<img width="329" alt="screen shot 2017-02-18 at 22 59 03" src="https://cloud.githubusercontent.com/assets/834902/23097184/03d5d238-f62e-11e6-9f58-1775b1d2f862.png">
