### PR TITLE
Calculations for banks and turns

### DIFF
--- a/mic/src/mic/AutoBump.java
+++ b/mic/src/mic/AutoBump.java
@@ -334,9 +334,7 @@ public class AutoBump extends AbstractBuildable {
 
         graphics.setColor(Color.orange);
         graphics.setStroke(new BasicStroke(2.0f));
-        for (int i = 0; i < 50000; i++) {
-            graphics.draw(renderPath);
-        }
+        graphics.draw(renderPath);
     }
 
     private void performTemplateMove(final ManeuverPaths path) {

--- a/mic/src/mic/AutoBump.java
+++ b/mic/src/mic/AutoBump.java
@@ -334,7 +334,9 @@ public class AutoBump extends AbstractBuildable {
 
         graphics.setColor(Color.orange);
         graphics.setStroke(new BasicStroke(2.0f));
-        graphics.draw(renderPath);
+        for (int i = 0; i < 50000; i++) {
+            graphics.draw(renderPath);
+        }
     }
 
     private void performTemplateMove(final ManeuverPaths path) {

--- a/mic/src/mic/manuvers/CurvedPaths.java
+++ b/mic/src/mic/manuvers/CurvedPaths.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 
 /**
  * Created by amatheny on 2/17/17.
+ * Path calculations implemented by haslo on 2017-02-24
  */
 public enum CurvedPaths implements ManeuverPath {
     LBk1(80 * 2.825, true, true, false, 0.95),
@@ -48,9 +49,15 @@ public enum CurvedPaths implements ManeuverPath {
     //  utility
     // --------- //
 
+    /**
+     * length of bank and turn arcs
+     */
     private double calcArcLength() {
         return 2 * Math.PI * this.radius / (this.bank ? 8.0 : 4.0);
     }
+    /**
+     * angle that a vector from origin to target has in the Vassal map space
+     */
     private double calcAngle(Vector origin, Vector target) {
         if (target.x > origin.x) {
             return Math.atan((target.y - origin.y) / (target.x - origin.x));
@@ -58,18 +65,28 @@ public enum CurvedPaths implements ManeuverPath {
             return Math.PI + Math.atan((target.y - origin.y) / (target.x - origin.x));
         }
     }
+    /**
+     * scaling function for the input parameters to the position calculation methods - improves approximation by
+     * reducing the errors introduced by bases getting "shorter" through Pythagoras; version for the front edge of the base
+     */
     private double frontPercentage(double percentage, boolean isLargeBase) {
-        // front goes faster in the first half, slower in the second
+        // small bases need less adjustment because their error is smaller (they're smaller relative to the template)
         double adjustedApproximationMultiplier = isLargeBase ? this.approximationMultiplier : Math.sqrt(this.approximationMultiplier);
+        // front goes faster in the first half, slower in the second
         if (percentage < 0.5) {
             return (2 - adjustedApproximationMultiplier) * percentage;
         } else {
             return ((2 - adjustedApproximationMultiplier) * 0.5) + (adjustedApproximationMultiplier * (percentage - 0.5));
         }
     }
+    /**
+     * scaling function for the input parameters to the position calculation methods - improves approximation by
+     * reducing the errors introduced by bases getting "shorter" through Pythagoras; version for the back edge of the base
+     */
     private double backPercentage(double percentage, boolean isLargeBase) {
-        // front goes slower in the first half, faster in the second
+        // small bases need less adjustment because their error is smaller (they're smaller relative to the template)
         double adjustedApproximationMultiplier = isLargeBase ? this.approximationMultiplier : Math.sqrt(this.approximationMultiplier);
+        // front goes slower in the first half, faster in the second
         if (percentage < 0.5) {
             return adjustedApproximationMultiplier * percentage;
         } else {
@@ -81,12 +98,21 @@ public enum CurvedPaths implements ManeuverPath {
     //  banks
     // ------- //
 
+    /**
+     * calculate the position and angle of a bit of path; uses getBankFrontPosition and getBankBackPosition
+     * @param percentage at what percentage (from 0 to 1) of the entire path should the position be calculated?
+     * @param baseLength length of the base to calculate
+     * @param arcLength pre-computed length of the arc that the template's center forms
+     * @param isLargeBase small and large bases need different computation
+     * @return a PathPart with x, y and angle (degrees)
+     */
     private PathPart getBankPart(double percentage, double baseLength, double arcLength, boolean isLargeBase) {
         double currentFrontDistance = frontPercentage(percentage, isLargeBase) * (baseLength + arcLength);
         double currentBackDistance = backPercentage(percentage, isLargeBase) * (baseLength + arcLength);
         Vector frontPosition = getBankFrontPosition(currentFrontDistance, baseLength, arcLength);
         Vector backPosition = getBankBackPosition(currentBackDistance, baseLength, arcLength);
         double angle = 270 + (this.reverse ? 180 : 0) - (calcAngle(backPosition, frontPosition) / (Math.PI * 2) * 360.0);
+        // the position we want to return is in the center between front and back
         double x = (frontPosition.x + backPosition.x) / 2;
         double y = (frontPosition.y + backPosition.y) / 2;
         if (this.left) {
@@ -95,13 +121,18 @@ public enum CurvedPaths implements ManeuverPath {
             return new PathPart(x, y, angle);
         }
     }
+    /**
+     * actual computation of x and y values of a bit of path for banks, for the front of the base
+     */
     private Vector getBankFrontPosition(double currentDistance, double baseLength, double arcLength) {
         if (currentDistance < arcLength) {
+            // first bit, the arc of the bank template
             double alpha = currentDistance / arcLength * (Math.PI / 4.0);
             double x = this.radius - (Math.cos(alpha) * this.radius);
             double y = (Math.sin(alpha) * this.radius) + (baseLength / 2); // upwards
             return new Vector(x, this.reverse ? y : -y);
         } else {
+            // straight bit (template extension) at a 45° angle after the arc
             double startX = this.radius - (Math.cos(Math.PI / 4.0) * this.radius);
             double startY = (Math.sin(Math.PI / 4.0) * this.radius) + (baseLength / 2); // upwards
             double x = startX + ((currentDistance - arcLength) / Math.sqrt(2));
@@ -109,12 +140,17 @@ public enum CurvedPaths implements ManeuverPath {
             return new Vector(x, this.reverse ? y : -y);
         }
     }
+    /**
+     * actual computation of x and y values of a bit of path for banks, for the back of the base
+     */
     private Vector getBankBackPosition(double currentDistance, double baseLength, double arcLength) {
         if (currentDistance < baseLength) {
+            // go through the base first, straight (template extension)
             double x = 0;
             double y = -(baseLength / 2) + currentDistance; // upwards
             return new Vector(x, this.reverse ? y : -y);
         } else {
+            // second bit, the arc of the bank template
             double alpha = (currentDistance - baseLength) / arcLength * (Math.PI / 4.0);
             double x = this.radius - (Math.cos(alpha) * this.radius);
             double y = (baseLength / 2) + (Math.sin(alpha) * this.radius); // upwards
@@ -126,11 +162,20 @@ public enum CurvedPaths implements ManeuverPath {
     //  turns  //
     // ------- //
 
+    /**
+     * calculate the position and angle of a bit of path; uses getTurnFrontPosition and getTurnBackPosition
+     * @param percentage at what percentage (from 0 to 1) of the entire path should the position be calculated?
+     * @param baseLength length of the base to calculate
+     * @param arcLength pre-computed length of the arc that the template's center forms
+     * @param isLargeBase small and large bases need different computation
+     * @return a PathPart with x, y and angle (degrees)
+     */
     private PathPart getTurnPart(double percentage, double baseLength, double arcLength, boolean isLargeBase) {
         double currentFrontDistance = frontPercentage(percentage, isLargeBase) * (baseLength + arcLength);
         double currentBackDistance = backPercentage(percentage, isLargeBase) * (baseLength + arcLength);
         Vector frontPosition = getTurnFrontPosition(currentFrontDistance, baseLength, arcLength);
         Vector backPosition = getTurnBackPosition(currentBackDistance, baseLength, arcLength);
+        // the position we want to return is in the center between front and back
         double angle = 270 + (this.reverse ? 180 : 0) - (calcAngle(backPosition, frontPosition) / (Math.PI * 2) * 360.0);
         double x = (frontPosition.x + backPosition.x) / 2;
         double y = (frontPosition.y + backPosition.y) / 2;
@@ -140,24 +185,34 @@ public enum CurvedPaths implements ManeuverPath {
             return new PathPart(x, y, angle);
         }
     }
+    /**
+     * actual computation of x and y values of a bit of path for turns, for the front of the base
+     */
     private Vector getTurnFrontPosition(double currentDistance, double baseLength, double arcLength) {
         if (currentDistance < arcLength) {
+            // first bit, the arc of the turn template
             double alpha = currentDistance / arcLength * (Math.PI / 2.0);
             double x = this.radius - (Math.cos(alpha) * this.radius);
             double y = (Math.sin(alpha) * this.radius) + (baseLength / 2); // upwards
             return new Vector(x, this.reverse ? y : -y);
         } else {
+            // straight bit (template extension) horizontally after the arc
             double x = (currentDistance - arcLength) + this.radius;
             double y = this.radius + (baseLength / 2); // upwards
             return new Vector(x, this.reverse ? y : -y);
         }
     }
+    /**
+     * actual computation of x and y values of a bit of path for turns, for the back of the base
+     */
     private Vector getTurnBackPosition(double currentDistance, double baseLength, double arcLength) {
         if (currentDistance < baseLength) {
+            // go through the base first, straight (template extension)
             double x = 0;
             double y = -(baseLength / 2) + currentDistance; // upwards
             return new Vector(x, this.reverse ? y : -y);
         } else {
+            // second bit, the arc of the turn template
             double alpha = (currentDistance - baseLength) / arcLength * (Math.PI / 2.0);
             double x = this.radius - (Math.cos(alpha) * this.radius);
             double y = (baseLength / 2) + (Math.sin(alpha) * this.radius); // upwards
@@ -169,6 +224,9 @@ public enum CurvedPaths implements ManeuverPath {
     //  use banks and turns to calculate paths  //
     // ---------------------------------------- //
 
+    /**
+     * The method that this entire class is about
+     */
     public List<PathPart> getPathParts(int numSegments, double baseOffset, boolean isLargeBase) {
         // init
         List<PathPart> parts = Lists.newArrayList();

--- a/mic/src/mic/manuvers/CurvedPaths.java
+++ b/mic/src/mic/manuvers/CurvedPaths.java
@@ -54,20 +54,22 @@ public enum CurvedPaths implements ManeuverPath {
             return Math.PI + Math.atan((target.y - origin.y) / (target.x - origin.x));
         }
     }
-    private double frontPercentage(double percentage) {
+    private double frontPercentage(double percentage, boolean isLargeBase) {
         // front goes faster in the first half, slower in the second
+        double adjustedApproximationMultiplier = isLargeBase ? this.approximationMultiplier : Math.sqrt(this.approximationMultiplier);
         if (percentage < 0.5) {
-            return (2 - this.approximationMultiplier) * percentage;
+            return (2 - adjustedApproximationMultiplier) * percentage;
         } else {
-            return ((2 - this.approximationMultiplier) * 0.5) + (this.approximationMultiplier * (percentage - 0.5));
+            return ((2 - adjustedApproximationMultiplier) * 0.5) + (adjustedApproximationMultiplier * (percentage - 0.5));
         }
     }
-    private double backPercentage(double percentage) {
+    private double backPercentage(double percentage, boolean isLargeBase) {
         // front goes slower in the first half, faster in the second
+        double adjustedApproximationMultiplier = isLargeBase ? this.approximationMultiplier : Math.sqrt(this.approximationMultiplier);
         if (percentage < 0.5) {
-            return this.approximationMultiplier * percentage;
+            return adjustedApproximationMultiplier * percentage;
         } else {
-            return (this.approximationMultiplier * 0.5) + ((2 - this.approximationMultiplier) * (percentage - 0.5));
+            return (adjustedApproximationMultiplier * 0.5) + ((2 - adjustedApproximationMultiplier) * (percentage - 0.5));
         }
     }
 
@@ -75,9 +77,9 @@ public enum CurvedPaths implements ManeuverPath {
     //  banks
     // ------- //
 
-    private PathPart getBankPart(double percentage, double baseLength, double arcLength) {
-        double currentFrontDistance = frontPercentage(percentage) * (baseLength + arcLength);
-        double currentBackDistance = backPercentage(percentage) * (baseLength + arcLength);
+    private PathPart getBankPart(double percentage, double baseLength, double arcLength, boolean isLargeBase) {
+        double currentFrontDistance = frontPercentage(percentage, isLargeBase) * (baseLength + arcLength);
+        double currentBackDistance = backPercentage(percentage, isLargeBase) * (baseLength + arcLength);
         Vector frontPosition = getBankFrontPosition(currentFrontDistance, baseLength, arcLength);
         Vector backPosition = getBankBackPosition(currentBackDistance, baseLength, arcLength);
         double angle = 270 - (calcAngle(backPosition, frontPosition) / (Math.PI * 2) * 360.0);
@@ -120,9 +122,9 @@ public enum CurvedPaths implements ManeuverPath {
     //  turns  //
     // ------- //
 
-    private PathPart getTurnPart(double percentage, double baseLength, double arcLength) {
-        double currentFrontDistance = frontPercentage(percentage) * (baseLength + arcLength);
-        double currentBackDistance = backPercentage(percentage) * (baseLength + arcLength);
+    private PathPart getTurnPart(double percentage, double baseLength, double arcLength, boolean isLargeBase) {
+        double currentFrontDistance = frontPercentage(percentage, isLargeBase) * (baseLength + arcLength);
+        double currentBackDistance = backPercentage(percentage, isLargeBase) * (baseLength + arcLength);
         Vector frontPosition = getTurnFrontPosition(currentFrontDistance, baseLength, arcLength);
         Vector backPosition = getTurnBackPosition(currentBackDistance, baseLength, arcLength);
         double angle = 270 - (calcAngle(backPosition, frontPosition) / (Math.PI * 2) * 360.0);
@@ -172,9 +174,9 @@ public enum CurvedPaths implements ManeuverPath {
         for (int i = 0; i < numSegments; i++) {
             double percentage = (double)i / (double)numSegments;
             if (this.bank) {
-                parts.add(getBankPart(percentage, baseLength, arcLength));
+                parts.add(getBankPart(percentage, baseLength, arcLength, isLargeBase));
             } else {
-                parts.add(getTurnPart(percentage, baseLength, arcLength));
+                parts.add(getTurnPart(percentage, baseLength, arcLength, isLargeBase));
             }
         }
         // done

--- a/mic/src/mic/manuvers/CurvedPaths.java
+++ b/mic/src/mic/manuvers/CurvedPaths.java
@@ -43,7 +43,7 @@ public enum CurvedPaths implements ManeuverPath {
         return this.bank ? QTR_PI : HALF_PI;
     }
 
-    public List<PathPart> getPathParts(int numSegments, double baseOffset) {
+    public List<PathPart> getPathParts(int numSegments, double baseOffset, boolean isLargeBase) {
         List<PathPart> parts = Lists.newArrayList();
         //Extended straight back segment
 

--- a/mic/src/mic/manuvers/CurvedPaths.java
+++ b/mic/src/mic/manuvers/CurvedPaths.java
@@ -8,28 +8,32 @@ import com.google.common.collect.Lists;
  * Created by amatheny on 2/17/17.
  */
 public enum CurvedPaths implements ManeuverPath {
-    LBk1(80 * 2.825, true, true, 0.95),
-    RBk1(80 * 2.825, false, true, 0.95),
-    LBk2(130 * 2.825, true, true, 0.98),
-    RBk2(130 * 2.825, false, true, 0.98),
-    LBk3(180 * 2.825, true, true, 1.0),
-    RBk3(180 * 2.825, false, true, 1.0),
+    LBk1(80 * 2.825, true, true, false, 0.95),
+    RBk1(80 * 2.825, false, true, false, 0.95),
+    LBk2(130 * 2.825, true, true, false, 0.98),
+    RBk2(130 * 2.825, false, true, false, 0.98),
+    LBk3(180 * 2.825, true, true, false, 1.0),
+    RBk3(180 * 2.825, false, true, false, 1.0),
 
-    LT1(35 * 2.825, true, false, 0.85),
-    RT1(35 * 2.825, false, false, 0.85),
-    LT2(62.5 * 2.825, true, false, 0.95),
-    RT2(62.5 * 2.825, false, false, 0.95),
-    LT3(90 * 2.825, true, false, 1.0),
-    RT3(90 * 2.825, false, false, 1.0);
+    RevLB1(80 * 2.825, true, true, true, 0.95),
+    RevRB1(80 * 2.825, false, true, true, 0.95),
 
-    private final boolean bank;
+    LT1(35 * 2.825, true, false, false, 0.85),
+    RT1(35 * 2.825, false, false, false, 0.85),
+    LT2(62.5 * 2.825, true, false, false, 0.95),
+    RT2(62.5 * 2.825, false, false, false, 0.95),
+    LT3(90 * 2.825, true, false, false, 1.0),
+    RT3(90 * 2.825, false, false, false, 1.0);
+
+    private boolean bank, reverse;
     boolean left;
     private double radius, approximationMultiplier;
 
-    CurvedPaths(double radius, boolean left, boolean bank, double approximationMultiplier) {
+    CurvedPaths(double radius, boolean left, boolean bank, boolean reverse, double approximationMultiplier) {
         this.radius = radius;
         this.left = left;
         this.bank = bank;
+        this.reverse = reverse;
         this.approximationMultiplier = approximationMultiplier;
     }
     public double getFinalAngleOffset() {
@@ -82,7 +86,7 @@ public enum CurvedPaths implements ManeuverPath {
         double currentBackDistance = backPercentage(percentage, isLargeBase) * (baseLength + arcLength);
         Vector frontPosition = getBankFrontPosition(currentFrontDistance, baseLength, arcLength);
         Vector backPosition = getBankBackPosition(currentBackDistance, baseLength, arcLength);
-        double angle = 270 - (calcAngle(backPosition, frontPosition) / (Math.PI * 2) * 360.0);
+        double angle = 270 + (this.reverse ? 180 : 0) - (calcAngle(backPosition, frontPosition) / (Math.PI * 2) * 360.0);
         double x = (frontPosition.x + backPosition.x) / 2;
         double y = (frontPosition.y + backPosition.y) / 2;
         if (this.left) {
@@ -96,25 +100,25 @@ public enum CurvedPaths implements ManeuverPath {
             double alpha = currentDistance / arcLength * (Math.PI / 4.0);
             double x = this.radius - (Math.cos(alpha) * this.radius);
             double y = (Math.sin(alpha) * this.radius) + (baseLength / 2); // upwards
-            return new Vector(x, -y);
+            return new Vector(x, this.reverse ? y : -y);
         } else {
             double startX = this.radius - (Math.cos(Math.PI / 4.0) * this.radius);
             double startY = (Math.sin(Math.PI / 4.0) * this.radius) + (baseLength / 2); // upwards
             double x = startX + ((currentDistance - arcLength) / Math.sqrt(2));
             double y = startY + ((currentDistance - arcLength) / Math.sqrt(2)); // upwards
-            return new Vector(x, -y);
+            return new Vector(x, this.reverse ? y : -y);
         }
     }
     private Vector getBankBackPosition(double currentDistance, double baseLength, double arcLength) {
         if (currentDistance < baseLength) {
             double x = 0;
             double y = -(baseLength / 2) + currentDistance; // upwards
-            return new Vector(x, -y);
+            return new Vector(x, this.reverse ? y : -y);
         } else {
             double alpha = (currentDistance - baseLength) / arcLength * (Math.PI / 4.0);
             double x = this.radius - (Math.cos(alpha) * this.radius);
             double y = (baseLength / 2) + (Math.sin(alpha) * this.radius); // upwards
-            return new Vector(x, -y);
+            return new Vector(x, this.reverse ? y : -y);
         }
     }
 
@@ -127,7 +131,7 @@ public enum CurvedPaths implements ManeuverPath {
         double currentBackDistance = backPercentage(percentage, isLargeBase) * (baseLength + arcLength);
         Vector frontPosition = getTurnFrontPosition(currentFrontDistance, baseLength, arcLength);
         Vector backPosition = getTurnBackPosition(currentBackDistance, baseLength, arcLength);
-        double angle = 270 - (calcAngle(backPosition, frontPosition) / (Math.PI * 2) * 360.0);
+        double angle = 270 + (this.reverse ? 180 : 0) - (calcAngle(backPosition, frontPosition) / (Math.PI * 2) * 360.0);
         double x = (frontPosition.x + backPosition.x) / 2;
         double y = (frontPosition.y + backPosition.y) / 2;
         if (this.left) {
@@ -141,23 +145,23 @@ public enum CurvedPaths implements ManeuverPath {
             double alpha = currentDistance / arcLength * (Math.PI / 2.0);
             double x = this.radius - (Math.cos(alpha) * this.radius);
             double y = (Math.sin(alpha) * this.radius) + (baseLength / 2); // upwards
-            return new Vector(x, -y);
+            return new Vector(x, this.reverse ? y : -y);
         } else {
             double x = (currentDistance - arcLength) + this.radius;
             double y = this.radius + (baseLength / 2); // upwards
-            return new Vector(x, -y);
+            return new Vector(x, this.reverse ? y : -y);
         }
     }
     private Vector getTurnBackPosition(double currentDistance, double baseLength, double arcLength) {
         if (currentDistance < baseLength) {
             double x = 0;
             double y = -(baseLength / 2) + currentDistance; // upwards
-            return new Vector(x, -y);
+            return new Vector(x, this.reverse ? y : -y);
         } else {
             double alpha = (currentDistance - baseLength) / arcLength * (Math.PI / 2.0);
             double x = this.radius - (Math.cos(alpha) * this.radius);
             double y = (baseLength / 2) + (Math.sin(alpha) * this.radius); // upwards
-            return new Vector(x, -y);
+            return new Vector(x, this.reverse ? y : -y);
         }
     }
 

--- a/mic/src/mic/manuvers/ManeuverPath.java
+++ b/mic/src/mic/manuvers/ManeuverPath.java
@@ -6,5 +6,5 @@ import java.util.List;
  * Created by amatheny on 2/17/17.
  */
 public interface ManeuverPath {
-    List<PathPart> getPathParts(int numSegments, double baseOffset);
+    List<PathPart> getPathParts(int numSegments, double baseOffset, boolean isLargeBase);
 }

--- a/mic/src/mic/manuvers/ManeuverPaths.java
+++ b/mic/src/mic/manuvers/ManeuverPaths.java
@@ -19,6 +19,9 @@ public enum ManeuverPaths {
     RBk2(CurvedPaths.RBk2, CurvedPaths.LBk2),
     RBk3(CurvedPaths.RBk3, CurvedPaths.LBk3),
 
+    RevLB1(CurvedPaths.RevLB1, CurvedPaths.RevRB1),
+    RevRB1(CurvedPaths.RevRB1, CurvedPaths.RevLB1),
+
     LT1(CurvedPaths.LT1, CurvedPaths.RT1),
     LT2(CurvedPaths.LT2, CurvedPaths.RT2),
     LT3(CurvedPaths.LT3, CurvedPaths.RT3),

--- a/mic/src/mic/manuvers/ManeuverPaths.java
+++ b/mic/src/mic/manuvers/ManeuverPaths.java
@@ -45,7 +45,7 @@ public enum ManeuverPaths {
 
     private List<PathPart> getTransformedPathPartsInternal(ManeuverPath workingPath, double x, double y, double angleDegrees, boolean isLargeBase) {
         double baseOffset = isLargeBase ? 113 : 56.5;
-        List<PathPart> rawParts = workingPath.getPathParts(NUM_PATH_SEGMENTS, baseOffset);
+        List<PathPart> rawParts = workingPath.getPathParts(NUM_PATH_SEGMENTS, baseOffset, isLargeBase);
         List<PathPart> transformed = Lists.newArrayList();
 
         for (PathPart rawPart : rawParts) {
@@ -94,7 +94,7 @@ public enum ManeuverPaths {
         List<Point.Double> points = Lists.newArrayList();
 
         int segments = 100;
-        List<PathPart> parts = curvedPath.getPathParts(segments, baseLength );
+        List<PathPart> parts = curvedPath.getPathParts(segments, baseLength, bigBase);
         int minPathIndex = segments / 2;
         while(minPathIndex < segments*2.5) {
             PathPart partA = parts.get(minPathIndex);

--- a/mic/src/mic/manuvers/StraightPaths.java
+++ b/mic/src/mic/manuvers/StraightPaths.java
@@ -24,7 +24,7 @@ public enum StraightPaths implements ManeuverPath {
         return 0;
     }
 
-    public List<PathPart> getPathParts(int numSegments, double baseOffset) {
+    public List<PathPart> getPathParts(int numSegments, double baseOffset, boolean isLargeBase) {
         List<PathPart> parts = Lists.newArrayList();
 
         //Extended straight back segment


### PR DESCRIPTION
This PR replaces the calculations for banks and turns with separate calculations for the front and the back of the template (returning the center between the two as the place the template is supposed to be), and then an added hack that makes the result better approximate the actual position of the template.

Currently works for all forward turns and banks, and for backward 1 banks. Since reverse maneuvers are analogous to forward ones with `true` as the parameter `reverse` (and take identical parameters otherwise), more should be easy to add.