### PR TITLE
U-Wing pivot title should +1 AGI #18

### DIFF
--- a/mic/src/mic/AutoSquadSpawn.java
+++ b/mic/src/mic/AutoSquadSpawn.java
@@ -3,10 +3,7 @@ package mic;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.List;
 import java.util.Random;
 
 import javax.swing.*;
@@ -15,7 +12,6 @@ import javax.swing.*;
 import VASSAL.build.AbstractConfigurable;
 import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
-import VASSAL.build.module.Chatter;
 import VASSAL.build.module.GameComponent;
 import VASSAL.build.module.Map;
 import VASSAL.build.widget.PieceSlot;
@@ -136,7 +132,7 @@ public class AutoSquadSpawn extends AbstractConfigurable implements CommandEncod
 
                 totalUpgradeWidth += upgradePiece.boundingBox().getWidth();
 
-                totalSquadPoints += upgrade.getUpgradeData().getPoints();
+                totalSquadPoints += upgrade.getUpgradeDataDefault().getPoints();
             } //loop to next upgrade
 
             for (PieceSlot conditionSlot: ship.getConditions()) {

--- a/mic/src/mic/MasterUpgradeData.java
+++ b/mic/src/mic/MasterUpgradeData.java
@@ -14,9 +14,9 @@ import java.util.Map;
  */
 public class MasterUpgradeData extends ArrayList<MasterUpgradeData.UpgradeData> {
 
-  private static Map<String, UpgradeData> loadedData = null;
+  private static Map<String, List<UpgradeData>> loadedData = null;
 
-  public static UpgradeData getUpgradeData(String upgradeXwsId) {
+  public static List<UpgradeData> getUpgradeData(String upgradeXwsId) {
       if (loadedData == null) {
           loadData();
       }
@@ -28,7 +28,14 @@ public class MasterUpgradeData extends ArrayList<MasterUpgradeData.UpgradeData> 
       MasterUpgradeData data = Util.loadClasspathJson("upgrades.json", MasterUpgradeData.class);
 
       for(UpgradeData upgrade : data) {
-          loadedData.put(upgrade.getXws(), upgrade);
+          String key = upgrade.getXws();
+          List<UpgradeData> upgradeData = loadedData.get(key);
+          if (upgradeData == null)
+          {
+              upgradeData = new ArrayList<UpgradeData>();
+          }
+          upgradeData.add(upgrade);
+          loadedData.put(key, upgradeData);
       }
   }
 

--- a/mic/src/mic/VassalXWSPieceLoader.java
+++ b/mic/src/mic/VassalXWSPieceLoader.java
@@ -61,8 +61,8 @@ public class VassalXWSPieceLoader {
                         continue;
                     }
 
-                    if (upgrade.getUpgradeData() != null) {
-                        List<PieceSlot> foundConditions = getConditionsForCard(upgrade.getUpgradeData().getConditions());
+                    if (upgrade.getUpgradeDataDefault() != null) {
+                        List<PieceSlot> foundConditions = getConditionsForCard(upgrade.getUpgradeDataDefault().getConditions());
                         pilotPieces.getConditions().addAll(foundConditions);
                     }
 
@@ -167,12 +167,18 @@ public class VassalXWSPieceLoader {
             String mapKey = getUpgradeMapKey(upgradeType, upgradeName);
             VassalXWSPilotPieces.Upgrade upgradePiece = new VassalXWSPilotPieces.Upgrade(upgradeName, upgrade);
 
-            MasterUpgradeData.UpgradeData upgradeData = MasterUpgradeData.getUpgradeData(upgradeName);
+            List<MasterUpgradeData.UpgradeData> upgradeData = MasterUpgradeData.getUpgradeData(upgradeName);
             if (upgradeData != null) {
                 upgradePiece.setUpgradeData(upgradeData);
             }
-
-            upgradePiecesMap.put(mapKey, upgradePiece);
+            VassalXWSPilotPieces.Upgrade existingUpgradePiece = upgradePiecesMap.get(mapKey);
+            if (existingUpgradePiece == null) {
+                existingUpgradePiece = upgradePiece;
+            }
+            else {
+                existingUpgradePiece.addUpgradeData(upgradePiece.getUpgradeData());
+            }
+            upgradePiecesMap.put(mapKey, existingUpgradePiece);
         }
     }
 

--- a/mic/src/mic/VassalXWSPilotPieces.java
+++ b/mic/src/mic/VassalXWSPilotPieces.java
@@ -241,8 +241,19 @@ public class VassalXWSPilotPieces {
         String[] words = name.split(" ");
 
         if (name.length() <= maxLength) return name;
-        if (words.length == 1) return name.substring(0, maxLength);
-        if (isUnique && words[0].length() <= maxLength) return words[0];
+        if (words.length == 1) {
+            return name.substring(0, maxLength);
+        } else if (isUnique) {
+            if (XWConstants.SHIP_NAME_PREFIXES.contains(words[0])) {
+                if (words[1].length() <= maxLength) {
+                    return words[1];
+                } else {
+                    return words[1].substring(0, maxLength);
+                }
+            } else {
+                return words[0];
+            }
+        }
 
         String firstLetters = "";
         for (String s: words){

--- a/mic/src/mic/VassalXWSPilotPieces.java
+++ b/mic/src/mic/VassalXWSPilotPieces.java
@@ -155,7 +155,7 @@ public class VassalXWSPilotPieces {
         int hullModifier = 0;
 
         for (Upgrade upgrade : this.upgrades) {
-            for(MasterUpgradeData.UpgradeGrants modifier : upgrade.getUpgradeData().getGrants()) {
+            for(MasterUpgradeData.UpgradeGrants modifier : upgrade.getUpgradeDataDefault().getGrants()) {
                 if (modifier.isStatsModifier()) {
                     String name = modifier.getName();
                     int value = modifier.getValue();
@@ -254,7 +254,7 @@ public class VassalXWSPilotPieces {
     public static class Upgrade {
         private String xwsName;
         private PieceSlot pieceSlot;
-        private MasterUpgradeData.UpgradeData upgradeData;
+        private List<MasterUpgradeData.UpgradeData> upgradeData;
 
         public Upgrade(String xwsName, PieceSlot pieceSlot) {
             this.xwsName = xwsName;
@@ -269,12 +269,20 @@ public class VassalXWSPilotPieces {
             return this.pieceSlot;
         }
 
-        public MasterUpgradeData.UpgradeData getUpgradeData() {
+        public MasterUpgradeData.UpgradeData getUpgradeDataDefault() {
+            return upgradeData.get(0);
+        }
+
+        public List<MasterUpgradeData.UpgradeData> getUpgradeData() {
             return upgradeData;
         }
 
-        public void setUpgradeData(MasterUpgradeData.UpgradeData upgradeData) {
+        public void setUpgradeData(List<MasterUpgradeData.UpgradeData> upgradeData) {
             this.upgradeData = upgradeData;
+        }
+
+        public void addUpgradeData(List<MasterUpgradeData.UpgradeData> upgradeData) {
+            this.upgradeData.addAll(upgradeData);
         }
 
         public GamePiece cloneGamePiece() {

--- a/mic/src/mic/XWConstants.java
+++ b/mic/src/mic/XWConstants.java
@@ -1,0 +1,21 @@
+package mic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by TerTer on 2017-02-23.
+ */
+public class XWConstants {
+    private static String THE = "The";
+    private static String COLONEL = "Colonel";
+    private static String LIEUTENANT = "Lieutenant";
+
+    public static List<String> SHIP_NAME_PREFIXES = new ArrayList<String>();
+    static
+    {
+        SHIP_NAME_PREFIXES.add(THE);
+        SHIP_NAME_PREFIXES.add(COLONEL);
+        SHIP_NAME_PREFIXES.add(LIEUTENANT);
+    }
+}

--- a/mic/swxwmg.vmod-unpacked/upgrades.json
+++ b/mic/swxwmg.vmod-unpacked/upgrades.json
@@ -2663,22 +2663,35 @@
     "id": 231
   },
   {
-    "image": "upgrades/Elite/adaptability-decrease.png",
-    "text": "Decrease your pilot skill value by 1.",
-    "name": "Adaptability (-1)",
-    "xws": "adaptability",
-    "points": 0,
-    "slot": "Elite",
-    "id": 232
-  },
-  {
     "image": "upgrades/Elite/adaptability-increase.png",
     "text": "Increase your pilot skill value by 1.",
     "name": "Adaptability (+1)",
     "xws": "adaptability",
     "points": 0,
     "slot": "Elite",
-    "id": 233
+    "id": 232,"grants": [
+    {
+      "type": "stats",
+      "name": "skill",
+      "value": 1
+    }
+  ]
+  },
+  {
+    "image": "upgrades/Elite/adaptability-decrease.png",
+    "text": "Decrease your pilot skill value by 1.",
+    "name": "Adaptability (-1)",
+    "xws": "adaptability",
+    "points": 0,
+    "slot": "Elite",
+    "id": 233,
+    "grants": [
+      {
+        "type": "stats",
+        "name": "skill",
+        "value": -1
+      }
+    ]
   },
   {
     "image": "upgrades/System/electronic-baffle.png",
@@ -3115,7 +3128,14 @@
     "ship": [
       "U-Wing"
     ],
-    "id": 271
+    "id": 271,
+    "grants": [
+      {
+        "type": "stats",
+        "name": "agility",
+        "value": 1
+      }
+    ]
   },
   {
     "image": "upgrades/Title/pivot-wing-landing.png",


### PR DESCRIPTION
U-Wing pivot title should +1 AGI #18
Made changes, to load all variants of upgrade card. So Double sided will be load both variants. Code for now will only then take first one registered card.
Example if we have pivotwing attack and landing in that order, attack card will be taken. If we change order in json file, then landing will be taken.

This also gives ability later maybe, when card is flipped, to take other grants of it.