### PR TITLE
Fix for spinning 180 at start of curved path

### DIFF
--- a/mic/src/mic/manuvers/CurvedPaths.java
+++ b/mic/src/mic/manuvers/CurvedPaths.java
@@ -66,7 +66,7 @@ public enum CurvedPaths implements ManeuverPath {
      * angle that a vector from origin to target has in the Vassal map space
      */
     private double calcAngle(Vector origin, Vector target) {
-        if (target.x > origin.x) {
+        if (target.x >= origin.x) {
             return Math.atan((target.y - origin.y) / (target.x - origin.x));
         } else {
             return Math.PI + Math.atan((target.y - origin.y) / (target.x - origin.x));


### PR DESCRIPTION
@haslo does this work ok?

The 180 spin was happing at the first place on the path when target.x and origin.x were equal.